### PR TITLE
Included option for setting the servers timezone in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ services:
       # 3. withings_tokens.pkl (Session Tokens)
       - ./data:/app/data
     environment:
+      # Set your local Timezone e.g. Europe/Berlin
+      - TZ=Europe/Berlin
       # OPTIONAL: You can set these if you prefer env vars over the Web UI.
       # If not set, the app will use the values you save in the Web UI.
       - WITHINGS_CLIENT_ID

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       # 3. withings_tokens.pkl (Session Tokens)
       - ./data:/app/data
     environment:
+      # Set your local Timezone e.g. Europe/Berlin
+      - TZ=Europe/Berlin
       # OPTIONAL: You can set these if you prefer env vars over the Web UI.
       # If not set, the app will use the values you save in the Web UI.
       - WITHINGS_CLIENT_ID


### PR DESCRIPTION
I have updated the docker-compose.yml and the README.md section to include an option for setting the timezone of the server.