### PR TITLE
feat: add app login and update checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ pip-delete-this-directory.txt
 .vscode/
 .idea/
 
+# AI assistant notes (local only, not part of the public repo)
+CLAUDE.md
+
 # Distribution / Packaging
 build/
 dist/

--- a/server.py
+++ b/server.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template_string, request, jsonify, render_template
+from flask import Flask, request, jsonify, render_template, redirect, url_for, session
 import sys
 import io
 import contextlib
@@ -7,6 +7,8 @@ import json
 import os
 import atexit
 import time
+import secrets
+from werkzeug.security import generate_password_hash, check_password_hash
 
 # Force immediate log output
 print("DEBUG: Server module loading...", flush=True)
@@ -51,6 +53,44 @@ if not os.path.exists(DATA_DIR):
         print(f"DEBUG: Created data directory at {DATA_DIR}", flush=True)
     except Exception as e:
         print(f"DEBUG: Failed to create data directory. Error type: {type(e).__name__}", flush=True)
+
+# Login Auth Setup
+AUTH_FILE = os.path.join(DATA_DIR, "auth.json")
+SECRET_KEY_FILE = os.path.join(DATA_DIR, "secret_key")
+DEFAULT_PASSWORD = "admin"
+
+def get_or_create_secret_key():
+    if os.path.exists(SECRET_KEY_FILE):
+        with open(SECRET_KEY_FILE, 'r') as f:
+            key = f.read().strip()
+            if key:
+                return key
+    key = secrets.token_hex(32)
+    with open(SECRET_KEY_FILE, 'w') as f:
+        f.write(key)
+    return key
+
+def load_auth():
+    try:
+        with open(AUTH_FILE, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+def save_auth(data):
+    with open(AUTH_FILE, 'w') as f:
+        json.dump(data, f)
+
+def init_auth():
+    if not os.path.exists(AUTH_FILE):
+        save_auth({"password_hash": generate_password_hash(DEFAULT_PASSWORD)})
+        print(f"DEBUG: No login password set yet. Default login password is '{DEFAULT_PASSWORD}' "
+              f"- please change it under Credentials after logging in.", flush=True)
+
+init_auth()
+app.secret_key = get_or_create_secret_key()
+app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
+app.config['SESSION_COOKIE_HTTPONLY'] = True
 
 DB_PATH = os.path.join(DATA_DIR, "garmin_import.db")
 
@@ -219,6 +259,84 @@ try:
 except Exception as e:
     print(f"DEBUG: Failed to restore schedule. Error type: {type(e).__name__}", flush=True)
     # Don't exit, just continue without schedule
+
+PUBLIC_ENDPOINTS = {'login', 'logout', 'static'}
+APP_VERSION = "1.8.0"
+GITHUB_REPO = "kilooo/grrminsync"
+
+@app.before_request
+def require_login():
+    if request.endpoint in PUBLIC_ENDPOINTS:
+        return
+    if session.get('authenticated'):
+        return
+    if request.method == 'GET':
+        return redirect(url_for('login', next=request.path))
+    return jsonify({"message": "Not authenticated. Please log in again."}), 401
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        password = request.form.get('password', '')
+        auth_data = load_auth()
+        if auth_data and check_password_hash(auth_data.get('password_hash', ''), password):
+            session['authenticated'] = True
+            next_url = request.args.get('next') or '/'
+            if not next_url.startswith('/') or next_url.startswith('//'):
+                next_url = '/'
+            return redirect(next_url)
+        error = "Incorrect password"
+    return render_template('login.html', error=error)
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('login'))
+
+@app.route('/account/password', methods=['POST'])
+def change_password():
+    current = request.form.get('current_password', '')
+    new = request.form.get('new_password', '')
+
+    auth_data = load_auth()
+    if not auth_data or not check_password_hash(auth_data.get('password_hash', ''), current):
+        return jsonify({"message": "Current password is incorrect"}), 400
+    if len(new) < 4:
+        return jsonify({"message": "New password must be at least 4 characters"}), 400
+
+    save_auth({"password_hash": generate_password_hash(new)})
+    return jsonify({"message": "Password updated successfully"})
+
+def _version_tuple(v):
+    parts = []
+    for p in v.split('.'):
+        num = ''.join(ch for ch in p if ch.isdigit())
+        parts.append(int(num) if num else 0)
+    return tuple(parts)
+
+@app.route('/system/update-check')
+def check_for_update():
+    try:
+        resp = requests.get(
+            f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest",
+            timeout=5, headers={"Accept": "application/vnd.github+json"}
+        )
+        if resp.status_code != 200:
+            return jsonify({"current": APP_VERSION, "error": f"GitHub returned status {resp.status_code}"}), 502
+
+        release = resp.json()
+        latest_tag = release.get('tag_name', '').lstrip('v')
+        update_available = bool(latest_tag) and _version_tuple(latest_tag) > _version_tuple(APP_VERSION)
+
+        return jsonify({
+            "current": APP_VERSION,
+            "latest": latest_tag,
+            "update_available": update_available,
+            "release_url": release.get('html_url')
+        })
+    except Exception as e:
+        return jsonify({"current": APP_VERSION, "error": f"Error type: {type(e).__name__}"}), 502
 
 @app.route('/')
 def index():

--- a/templates/base.html
+++ b/templates/base.html
@@ -1022,6 +1022,19 @@
                     Auto
                 </button>
             </div>
+
+            <div style="margin-top: 14px; padding-top: 14px; border-top: 1px solid var(--sidebar-border); display: flex; align-items: center; justify-content: space-between; gap: 8px;">
+                <button id="update-check-btn" onclick="checkForUpdate()" title="Check for updates"
+                    style="background: none; border: none; color: var(--sidebar-text); font-size: 0.75rem; cursor: pointer; padding: 4px 0; display: flex; align-items: center; gap: 6px;">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 11-6.22-8.56"></path><polyline points="21 4 21 10 15 10"></polyline></svg>
+                    <span id="update-check-label">Check for updates</span>
+                </button>
+                <a href="/logout" title="Log out"
+                    style="color: var(--sidebar-text); font-size: 0.75rem; text-decoration: none; display: flex; align-items: center; gap: 4px;">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"></path><polyline points="16 17 21 12 16 7"></polyline><line x1="21" y1="12" x2="9" y2="12"></line></svg>
+                    Logout
+                </a>
+            </div>
         </div>
     </aside>
 
@@ -1085,6 +1098,28 @@
                 document.body.classList.remove('sidebar-open');
             }
         });
+
+        function checkForUpdate() {
+            const label = document.getElementById('update-check-label');
+            label.innerText = 'Checking...';
+            fetch('/system/update-check')
+                .then(r => r.json())
+                .then(data => {
+                    if (data.error) {
+                        label.innerText = 'Check failed';
+                        return;
+                    }
+                    if (data.update_available) {
+                        label.innerHTML = `New version ${data.latest} available`;
+                        const btn = document.getElementById('update-check-btn');
+                        btn.onclick = () => window.open(data.release_url, '_blank');
+                        btn.style.color = 'var(--success, #10b981)';
+                    } else {
+                        label.innerText = `Up to date (v${data.current})`;
+                    }
+                })
+                .catch(() => { label.innerText = 'Check failed'; });
+        }
     </script>
     {% block scripts %}{% endblock %}
 </body>

--- a/templates/credentials.html
+++ b/templates/credentials.html
@@ -162,6 +162,49 @@
     </div>
 </div>
 
+<!-- App Login Password Card -->
+<div class="card">
+    <div class="card-header">
+        <div class="card-title">
+            <div class="card-title-icon">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                    stroke-linejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                    <path d="M7 11V7a5 5 0 0110 0v4"></path>
+                </svg>
+            </div>
+            <div>
+                <h2>App Login Password</h2>
+                <p class="card-desc" style="margin: 2px 0 0;">Change the password used to access this app's web
+                    interface.</p>
+            </div>
+        </div>
+    </div>
+
+    <div class="mt-4">
+        <div class="input-group">
+            <label>Current Password</label>
+            <input type="password" id="current-app-password" placeholder="••••••••" autocomplete="current-password">
+        </div>
+        <div class="input-group">
+            <label>New Password</label>
+            <input type="password" id="new-app-password" placeholder="At least 4 characters" autocomplete="new-password">
+        </div>
+
+        <div class="row mt-4">
+            <button class="btn btn-secondary" onclick="changeAppPassword()">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                    stroke-linejoin="round">
+                    <rect x="3" y="11" width="18" height="11" rx="2" ry="2"></rect>
+                    <path d="M7 11V7a5 5 0 0110 0v4"></path>
+                </svg>
+                Update Password
+            </button>
+            <span id="app-password-feedback"></span>
+        </div>
+    </div>
+</div>
+
 <!-- Reset Credentials Card -->
 <div class="card" style="border-color: var(--danger-soft);">
     <div class="card-header">
@@ -399,6 +442,41 @@
 
     // Run on startup
     checkConnectionStatus();
+
+    function changeAppPassword() {
+        const current = document.getElementById('current-app-password').value;
+        const next = document.getElementById('new-app-password').value;
+        const feedback = document.getElementById('app-password-feedback');
+
+        if (!current || !next) {
+            feedback.innerHTML = feedbackHtml('error', 'Both fields are required');
+            clearFeedback(feedback);
+            return;
+        }
+
+        const formData = new FormData();
+        formData.append('current_password', current);
+        formData.append('new_password', next);
+
+        feedback.innerHTML = feedbackHtml('loading', 'Updating...');
+
+        fetch('/account/password', { method: 'POST', body: formData })
+            .then(r => r.json().then(data => ({ ok: r.ok, data })))
+            .then(({ ok, data }) => {
+                if (ok) {
+                    feedback.innerHTML = feedbackHtml('success', 'Password Updated');
+                    document.getElementById('current-app-password').value = '';
+                    document.getElementById('new-app-password').value = '';
+                } else {
+                    feedback.innerHTML = feedbackHtml('error', data.message);
+                }
+                clearFeedback(feedback);
+            })
+            .catch(err => {
+                feedback.innerHTML = feedbackHtml('error', String(err));
+                clearFeedback(feedback);
+            });
+    }
 
     function clearAllCredentials() {
         if (!confirm("Are you sure you want to delete all saved API keys, passwords, and session tokens? You will need to reconnect both services.")) {

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Grrmin Sync — Login</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+    <script>
+        (function () {
+            try {
+                var t = localStorage.getItem('theme') || 'system';
+                var themeToApply = t === 'system'
+                    ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+                    : t;
+                document.documentElement.setAttribute('data-theme', themeToApply);
+            } catch (e) { }
+        })();
+    </script>
+    <style>
+        :root {
+            --accent: #4f46e5;
+            --accent-hover: #4338ca;
+            --accent-soft: rgba(79, 70, 229, 0.1);
+            --danger: #ef4444;
+            --danger-soft: rgba(239, 68, 68, 0.12);
+        }
+
+        :root[data-theme="light"] {
+            --bg: #f6f7fb;
+            --bg-gradient: radial-gradient(1200px 600px at 100% -10%, rgba(79, 70, 229, 0.08), transparent 60%),
+                radial-gradient(900px 500px at -10% 110%, rgba(14, 165, 233, 0.06), transparent 60%);
+            --surface: #ffffff;
+            --border: #e5e7eb;
+            --text: #0f172a;
+            --text-muted: #64748b;
+            --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.08), 0 4px 12px rgba(15, 23, 42, 0.04);
+        }
+
+        :root[data-theme="dark"] {
+            --bg: #0a0e1a;
+            --bg-gradient: radial-gradient(1200px 600px at 100% -10%, rgba(79, 70, 229, 0.18), transparent 60%),
+                radial-gradient(900px 500px at -10% 110%, rgba(14, 165, 233, 0.1), transparent 60%);
+            --surface: #111827;
+            --border: #1f2937;
+            --text: #e5e7eb;
+            --text-muted: #94a3b8;
+            --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.4), 0 4px 12px rgba(0, 0, 0, 0.2);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html, body {
+            margin: 0;
+            height: 100%;
+            font-family: 'Inter', -apple-system, sans-serif;
+            background: var(--bg);
+            background-image: var(--bg-gradient);
+            color: var(--text);
+        }
+
+        .login-wrap {
+            min-height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+
+        .login-card {
+            width: 100%;
+            max-width: 360px;
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 16px;
+            box-shadow: var(--shadow-lg);
+            padding: 32px 28px;
+        }
+
+        .login-logo {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 48px;
+            height: 48px;
+            border-radius: 12px;
+            background: var(--accent-soft);
+            color: var(--accent);
+            margin: 0 auto 16px;
+        }
+
+        h1 {
+            font-size: 1.15rem;
+            font-weight: 700;
+            text-align: center;
+            margin: 0 0 4px;
+        }
+
+        .subtitle {
+            text-align: center;
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            margin: 0 0 24px;
+        }
+
+        label {
+            display: block;
+            font-size: 0.8rem;
+            font-weight: 600;
+            margin-bottom: 6px;
+        }
+
+        input[type="password"] {
+            width: 100%;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid var(--border);
+            background: var(--bg);
+            color: var(--text);
+            font-size: 0.95rem;
+            font-family: inherit;
+        }
+
+        input[type="password"]:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+
+        .error-box {
+            margin-top: 14px;
+            padding: 10px 12px;
+            border-radius: 10px;
+            background: var(--danger-soft);
+            color: var(--danger);
+            font-size: 0.85rem;
+        }
+
+        button {
+            width: 100%;
+            margin-top: 18px;
+            padding: 11px;
+            border: none;
+            border-radius: 10px;
+            background: var(--accent);
+            color: white;
+            font-weight: 600;
+            font-size: 0.95rem;
+            cursor: pointer;
+            font-family: inherit;
+        }
+
+        button:hover {
+            background: var(--accent-hover);
+        }
+    </style>
+</head>
+
+<body>
+    <div class="login-wrap">
+        <div class="login-card">
+            <div class="login-logo">
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"
+                    stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M21 12a9 9 0 11-6.22-8.56"></path>
+                    <polyline points="21 4 21 10 15 10"></polyline>
+                </svg>
+            </div>
+            <h1>Grrmin Sync</h1>
+            <p class="subtitle">Please log in to continue</p>
+
+            <form method="POST" action="{{ url_for('login', next=request.args.get('next', '')) }}">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" autocomplete="current-password" autofocus required>
+                {% if error %}
+                <div class="error-box">{{ error }}</div>
+                {% endif %}
+                <button type="submit">Log In</button>
+            </form>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
- Require login before any page or API endpoint is reachable (default password "admin", changeable afterwards) - previously credentials, sync controls and history were reachable by anyone on the network
- Add password change form under Credentials
- Add "Check for Updates" control in the sidebar comparing the running version against the latest GitHub release
- Remove unused render_template_string import
- Ignore CLAUDE.md locally (AI assistant notes, not part of the repo)